### PR TITLE
✨ feat: 拖拽标签交互 (Drag-to-Tag) 与垃圾箱机制

### DIFF
--- a/Deck/Models/ClipboardItem.swift
+++ b/Deck/Models/ClipboardItem.swift
@@ -206,6 +206,7 @@ final class ClipboardItem: Identifiable, Equatable {
     let contentLength: Int
     var tagId: Int
     var isTemporary: Bool
+    var isDeleted: Bool = false
     /// 本机通过局域网共享（Multipeer / 直连）接收并写入历史的条目。
     var receivedFromLAN: Bool
     var isMissingFile: Bool = false
@@ -954,6 +955,7 @@ final class ClipboardItem: Identifiable, Equatable {
         contentLength: Int,
         tagId: Int = -1,
         isTemporary: Bool = false,
+        isDeleted: Bool = false,
         receivedFromLAN: Bool = false,
         id: Int64? = nil,
         uniqueId: String? = nil,
@@ -975,6 +977,7 @@ final class ClipboardItem: Identifiable, Equatable {
         self.contentLength = contentLength
         self.tagId = tagId
         self.isTemporary = isTemporary
+        self.isDeleted = isDeleted
         self.receivedFromLAN = receivedFromLAN
         self.id = id
         self.blobPath = blobPath

--- a/Deck/Services/DeckSQLManager.swift
+++ b/Deck/Services/DeckSQLManager.swift
@@ -121,6 +121,7 @@ enum Col {
     nonisolated static let uniqueId = Expression<String>("unique_id")
     nonisolated static let type = Expression<String>("type")
     nonisolated static let itemType = Expression<String>("item_type")
+    nonisolated static let isDeleted = Expression<Bool>("is_deleted")
     nonisolated static let data = Expression<Data>("data")
     nonisolated static let previewData = Expression<Data?>("preview_data")
     nonisolated static let ts = Expression<Int64>("timestamp")
@@ -3424,7 +3425,8 @@ final class DeckSQLManager: NSObject, @unchecked Sendable {
     /// - 7: 添加 received_from_lan 列（局域网共享接收标记，供 type:lan 过滤）
     /// - 8: 语义向量模型版本升级，清理旧缓存并后台重建
     /// - 9: CJK 统一 word-embedding 向量空间，清理旧缓存并后台重建
-    private static let currentSchemaVersion: Int32 = 9
+    /// - 10: 垃圾箱功能软删除，增加 is_deleted 字段
+    private static let currentSchemaVersion: Int32 = 10
     private static let fileSearchTextBackfillTargetVersion = 1
 
     private func getSchemaVersion() -> Int32 {
@@ -3469,6 +3471,7 @@ final class DeckSQLManager: NSObject, @unchecked Sendable {
         let needsCustomTitleMigration = currentVersion < 6
         let needsReceivedFromLanMigration = currentVersion < 7
         let needsSemanticEmbeddingModelMigration = currentVersion < 9
+        let needsIsDeletedMigration = currentVersion < 10
 
         let applyCustomTitleMigrationIfNeeded = { [weak self] in
             guard let self, needsCustomTitleMigration else { return }
@@ -3480,6 +3483,11 @@ final class DeckSQLManager: NSObject, @unchecked Sendable {
             guard let self, needsReceivedFromLanMigration else { return }
             self.addReceivedFromLanColumnIfNeeded()
             self.backfillReceivedFromLanFlagsIfNeeded()
+        }
+
+        let applyIsDeletedMigrationIfNeeded = { [weak self] in
+            guard let self, needsIsDeletedMigration else { return }
+            self.addIsDeletedColumnIfNeeded()
         }
 
         // Migration 0 -> 1: 添加 blob_path 列
@@ -3545,11 +3553,12 @@ final class DeckSQLManager: NSObject, @unchecked Sendable {
             }
             applyCustomTitleMigrationIfNeeded()
             applyReceivedFromLanMigrationIfNeeded()
+            applyIsDeletedMigrationIfNeeded()
             backfillSemanticEmbeddingsIfNeeded(targetVersion: Self.currentSchemaVersion)
             return migrationStoresLookHealthy()
         }
 
-        if needsTemporaryMigration || needsSourceAnchorMigration || needsEncryptionStateMigration || needsCustomTitleMigration || needsReceivedFromLanMigration || needsSemanticEmbeddingModelMigration {
+        if needsTemporaryMigration || needsSourceAnchorMigration || needsEncryptionStateMigration || needsCustomTitleMigration || needsReceivedFromLanMigration || needsSemanticEmbeddingModelMigration || needsIsDeletedMigration {
             if needsTemporaryMigration {
                 addTemporaryColumnIfNeeded()
             }
@@ -3561,6 +3570,7 @@ final class DeckSQLManager: NSObject, @unchecked Sendable {
             }
             applyCustomTitleMigrationIfNeeded()
             applyReceivedFromLanMigrationIfNeeded()
+            applyIsDeletedMigrationIfNeeded()
             if needsSemanticEmbeddingModelMigration {
                 resetSemanticEmbeddingCachesForModelUpgrade()
                 // Persist the schema/model marker immediately after the destructive
@@ -3677,6 +3687,23 @@ final class DeckSQLManager: NSObject, @unchecked Sendable {
             let encryptedValue = DeckUserDefaults.securityModeEnabled ? 1 : 0
             try db.run("UPDATE ClipboardHistory SET is_encrypted = ?", encryptedValue)
             log.info("Added is_encrypted column for encryption state")
+        }
+    }
+
+    private func addIsDeletedColumnIfNeeded() {
+        withDB {
+            guard let db = self.db else { return }
+            let stmt = try db.prepare("PRAGMA table_info(ClipboardHistory)")
+            var columns: [String] = []
+            while let row = try stmt.failableNext() {
+                if let name = row[1] as? String {
+                    columns.append(name)
+                }
+            }
+            if !columns.contains("is_deleted") {
+                try db.run("ALTER TABLE ClipboardHistory ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT 0")
+                log.info("Added is_deleted column for Trash bin support")
+            }
         }
     }
 
@@ -5271,13 +5298,23 @@ extension DeckSQLManager {
         scheduleDatabaseVacuum(reason: "delete all")
     }
 
-    func delete(id: Int64) async {
+    func delete(id: Int64, permanent: Bool = true) async {
         if let count: Int = await withDBAsync({
             guard let db = self.db, let table = self.table else { return 0 }
             let query = table.filter(Col.id == id)
-            return try db.run(query.delete())
+            
+            // First check if we should permanently delete
+            if permanent {
+                let deletedCount = try db.run(query.delete())
+                return deletedCount
+            } else {
+                // Soft delete
+                let update = query.update(Col.isDeleted <- true)
+                let updatedCount = try db.run(update)
+                return updatedCount
+            }
         }) {
-            await log.debug("Deleted item with id \(id): \(count) rows")
+            await log.debug("Deleted/Soft-deleted item with id \(id): \(count) rows")
             invalidateSearchCache(ids: [id])  // 只失效被删除的项
         }
     }
@@ -5555,8 +5592,8 @@ extension DeckSQLManager {
     /// 列表模式下的轻量查询：
     /// - 投影 `data` 列（大内容返回空 BLOB），避免把大 blob materialize 到 Swift Data
     /// - 维持与 UI 一致的排序：timestamp DESC, id DESC
-    private nonisolated func listModeBaseQuery(table: Table) -> Table {
-        table.select(
+    private nonisolated func listModeBaseQuery(table: Table, includeDeleted: Bool = false) -> Table {
+        let query = table.select(
             Col.id,
             Col.uniqueId,
             Col.type,
@@ -5574,8 +5611,14 @@ extension DeckSQLManager {
             Col.blobPath,
             Col.isTemporary,
             Col.isEncrypted,
-            Col.receivedFromLan
+            Col.receivedFromLan,
+            Col.isDeleted
         )
+        if includeDeleted {
+            return query
+        } else {
+            return query.filter(Col.isDeleted == false)
+        }
     }
 
     struct RowCursor: Sendable, Equatable {
@@ -6818,6 +6861,7 @@ extension DeckSQLManager {
             let storedItemType = try row.get(Col.itemType)
             let rawIsTemporary = (try? row.get(Col.isTemporary)) ?? false
             let receivedFromLAN = (try? row.get(Col.receivedFromLan)) ?? false
+            let isDeleted = (try? row.get(Col.isDeleted)) ?? false
             let storedIsEncrypted = try? row.get(Col.isEncrypted)
             let isTemporary = tagId == DeckTag.importantTagId ? false : rawIsTemporary
             
@@ -6920,6 +6964,7 @@ extension DeckSQLManager {
                 contentLength: length,
                 tagId: tagId,
                 isTemporary: isTemporary,
+                isDeleted: isDeleted,
                 receivedFromLAN: receivedFromLAN,
                 id: id,
                 uniqueId: resolvedUniqueId,
@@ -7423,6 +7468,32 @@ extension DeckSQLManager {
         } catch {
             log.warn("Failed to checkpoint WAL: \(error)")
             return false
+        }
+    }
+
+    // MARK: - Trash Bin Queries
+    func fetchDeletedItems(limit: Int = 100, offset: Int = 0) async -> [ClipboardItem] {
+        let rows: [Row] = await withReadDBAsync { db, table in
+            let query = self.listModeBaseQuery(table: table, includeDeleted: true)
+                .filter(Col.isDeleted == true)
+                .order(Col.ts.desc, Col.id.desc)
+                .limit(limit, offset: offset)
+            return Array(try db.prepare(query))
+        } ?? []
+        return await mapRowsToClipboardItems(rows, loadFullData: false)
+    }
+}
+extension DeckSQLManager {
+    func updateIsDeleted(id: Int64, isDeleted: Bool) async {
+        _ = await withDBAsync {
+            guard let db = self.db, let table = self.table else { return 0 }
+            let query = table.filter(Col.id == id)
+            let update = query.update(Col.isDeleted <- isDeleted)
+            let count = (try? db.run(update)) ?? 0
+            if count > 0 {
+                self.invalidateSearchCache(ids: [id])
+            }
+            return count
         }
     }
 }

--- a/Deck/Views/Components/ClipItemCardView.swift
+++ b/Deck/Views/Components/ClipItemCardView.swift
@@ -469,6 +469,9 @@ struct ClipItemCardView: View {
             .id(contextMenuID)
             .onDrag {
                 createDragItemProvider()
+            } preview: {
+                cardBody
+                    .opacity(0.3)
             }
             .onChange(of: item.searchText) { _, _ in
                 contextMenuID = UUID()
@@ -531,7 +534,19 @@ struct ClipItemCardView: View {
     /// 创建拖拽时的 NSItemProvider
     private func createDragItemProvider() -> NSItemProvider {
         MainWindowController.shared.beginClipItemDragWindowLevelRelaxation()
-        return item.dragItemProvider()
+        let provider = item.dragItemProvider()
+        // 注册内部 item URL，供拖拽到标签功能使用（仅同进程可见）
+        if let itemId = item.id {
+            let urlString = "deckitem://item/\(itemId)"
+            provider.registerDataRepresentation(
+                forTypeIdentifier: UTType.url.identifier,
+                visibility: .ownProcess
+            ) { completion in
+                completion(urlString.data(using: .utf8), nil)
+                return nil
+            }
+        }
+        return provider
     }
 
     // MARK: - Title Editing

--- a/Deck/Views/Components/HistoryListView.swift
+++ b/Deck/Views/Components/HistoryListView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 import Foundation
 import AppKit
 import Carbon
+import UniformTypeIdentifiers
+import OSLog
 
 private nonisolated struct IndexedCollection<Base: RandomAccessCollection>: RandomAccessCollection {
     typealias Index = Base.Index
@@ -244,26 +246,30 @@ struct HistoryListView: View {
     }
     
     var body: some View {
-        Group {
-            // Bottom bar:
-            // - Vertical mode: queue bar and action bar are mutually exclusive (same slot)
-            // - Horizontal mode: queue bar has priority, otherwise ambient bar
-            if vm.layoutMode == .vertical {
-                contentSection
-                    .overlay(alignment: .bottom) {
-                        verticalBottomOverlay
-                    }
-            } else {
-                VStack(spacing: 0) {
+        VStack(spacing: 0) {
+            Group {
+                // Bottom bar:
+                // - Vertical mode: queue bar and action bar are mutually exclusive (same slot)
+                // - Horizontal mode: queue bar has priority, otherwise ambient bar
+                if vm.layoutMode == .vertical {
                     contentSection
+                        .overlay(alignment: .bottom) {
+                            verticalBottomOverlay
+                        }
+                } else {
+                    VStack(spacing: 0) {
+                        contentSection
 
-                    if pasteQueue.isQueueMode {
-                        queueStatusBar
-                    } else if !dataStore.items.isEmpty && DeckUserDefaults.showAmbientBar {
-                        ASCIIArtBarView()
+                        if pasteQueue.isQueueMode {
+                            queueStatusBar
+                        } else if !dataStore.items.isEmpty && DeckUserDefaults.showAmbientBar {
+                            ASCIIArtBarView()
+                        }
                     }
                 }
             }
+
+            tagDropBar
         }
         .onAppear {
             setupKeyboardHandlers()
@@ -553,6 +559,19 @@ struct HistoryListView: View {
         }
         .padding(.horizontal, Const.space12)
         .frame(height: bottomBarHeight)
+    }
+
+    /// 标签拖拽接收条 — 拖拽剪贴项到标签上即可快速分配
+    @ViewBuilder
+    private var tagDropBar: some View {
+        let userTags = vm.tags.filter { !$0.isSystem }
+        let importantTag = vm.tags.first(where: { $0.isImportant })
+        if !dataStore.items.isEmpty, !userTags.isEmpty || importantTag != nil {
+            TagDropBarView(
+                userTags: userTags,
+                importantTag: importantTag
+            )
+        }
     }
     
     private var scrollContent: some View {
@@ -2424,6 +2443,275 @@ private struct OverlayToolbarTextButton: View {
         .contentShape(Capsule())
         .onHover { hovering in
             isHovered = hovering
+        }
+    }
+}
+
+// MARK: - Tag Drop Bar
+
+/// 标签拖拽接收条 — 显示在历史列表底部，拖拽剪贴项到标签上即可快速分配
+private struct TagDropBarView: View {
+    let userTags: [DeckTag]
+    let importantTag: DeckTag?
+
+    @State private var hoveredTagId: Int? = nil
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                Image(systemName: "tag.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.tertiary)
+
+                if let importantTag {
+                    TagDropPill(tag: importantTag, hoveredTagId: $hoveredTagId)
+                }
+
+                ForEach(userTags) { tag in
+                    TagDropPill(tag: tag, hoveredTagId: $hoveredTagId)
+                }
+                
+                Spacer(minLength: 8)
+                
+                DeleteAndTrashComboButton()
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+        }
+        .frame(height: 26)
+        .background(.ultraThinMaterial)
+    }
+}
+
+private struct DeleteAndTrashComboButton: View {
+    @State private var isDeleteHovered = false
+    @State private var showTrash = false
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            // Left part: Delete Dropzone
+            Image(systemName: "trash")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(isDeleteHovered ? .white : .primary)
+                .frame(width: 24, height: 20)
+                .background(isDeleteHovered ? Color.red : Color.black.opacity(0.2))
+                .onDrop(of: [.url], isTargeted: $isDeleteHovered) { providers in
+                    defer { isDeleteHovered = false }
+                    guard let provider = providers.first else { return false }
+                    provider.loadDataRepresentation(forTypeIdentifier: UTType.url.identifier) { data, error in
+                        guard let data = data,
+                              let urlString = String(data: data, encoding: .utf8),
+                              let url = URL(string: urlString),
+                              url.scheme == "deckitem",
+                              let itemId = Int64(url.lastPathComponent)
+                        else { return }
+                        DispatchQueue.main.async {
+                            Task {
+                                await DeckSQLManager.shared.delete(id: itemId, permanent: false)
+                                DeckDataStore.shared.loadNextPage() // Refresh list slightly
+                            }
+                        }
+                    }
+                    return true
+                }
+            
+            Divider()
+                .frame(height: 12)
+                .background(Color.white.opacity(0.3))
+            
+            // Right part: Trash Bin Toggle
+            Button {
+                showTrash = true
+            } label: {
+                Image(systemName: "archivebox")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.primary)
+                    .frame(width: 24, height: 20)
+                    .background(Color.black.opacity(0.2))
+            }
+            .buttonStyle(.plain)
+        }
+        .clipShape(Capsule())
+        .popover(isPresented: $showTrash, arrowEdge: .top) {
+            TrashListView()
+                .frame(width: 320, height: 400)
+        }
+    }
+}
+
+private struct TrashListView: View {
+    @State private var deletedItems: [ClipboardItem] = []
+    @State private var itemToDelete: ClipboardItem? = nil
+    
+    var body: some View {
+        VStack {
+            Text("垃圾箱")
+                .font(.headline)
+                .padding(.top)
+            
+            if deletedItems.isEmpty {
+                Text("垃圾箱是空的")
+                    .foregroundColor(.secondary)
+                    .padding()
+                Spacer()
+            } else {
+                List(deletedItems) { item in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.previewText(maxCharacters: 100).text)
+                                .lineLimit(1)
+                                .font(.system(size: 12))
+                            
+                            HStack(spacing: 4) {
+                                Text(item.appName)
+                                    .font(.system(size: 10))
+                                    .foregroundColor(.secondary)
+                                
+                                if item.tagId > 0, let tag = DeckViewModel.shared.tags.first(where: { $0.id == item.tagId }) {
+                                    Circle()
+                                        .fill(tag.color)
+                                        .frame(width: 6, height: 6)
+                                    Text(tag.name)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(tag.color)
+                                }
+                            }
+                        }
+                        Spacer()
+                        Button("恢复") {
+                            restore(item: item)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 2)
+                        .background(Color.blue.opacity(0.2))
+                        .cornerRadius(4)
+                        
+                        Button("彻底删除") {
+                            itemToDelete = item
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 2)
+                        .background(Color.red.opacity(0.2))
+                        .cornerRadius(4)
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+        .onAppear {
+            loadItems()
+        }
+        .alert(item: $itemToDelete) { item in
+            Alert(
+                title: Text("彻底删除"),
+                message: Text("确定要彻底删除这条记录吗？此操作不可撤销。"),
+                primaryButton: .destructive(Text("删除")) {
+                    permanentlyDelete(item: item)
+                },
+                secondaryButton: .cancel(Text("取消"))
+            )
+        }
+    }
+    
+    private func loadItems() {
+        Task {
+            let items = await DeckSQLManager.shared.fetchDeletedItems()
+            DispatchQueue.main.async {
+                self.deletedItems = items
+            }
+        }
+    }
+    
+    private func restore(item: ClipboardItem) {
+        guard let id = item.id else { return }
+        Task {
+            await DeckSQLManager.shared.updateIsDeleted(id: id, isDeleted: false)
+            loadItems()
+            DispatchQueue.main.async {
+                DeckDataStore.shared.loadNextPage()
+            }
+        }
+    }
+    
+    private func permanentlyDelete(item: ClipboardItem) {
+        guard let id = item.id else { return }
+        Task {
+            await DeckSQLManager.shared.delete(id: id, permanent: true)
+            loadItems()
+        }
+    }
+}
+
+/// 单个标签拖拽接收 pill
+private struct TagDropPill: View {
+    let tag: DeckTag
+    @Binding var hoveredTagId: Int?
+
+    private var isDropTargeted: Bool { hoveredTagId == tag.id }
+    private var isOthersTargeted: Bool { hoveredTagId != nil && hoveredTagId != tag.id }
+
+    private var isTargetedBinding: Binding<Bool> {
+        Binding(
+            get: { isDropTargeted },
+            set: { newValue in
+                if newValue {
+                    hoveredTagId = tag.id
+                } else if hoveredTagId == tag.id {
+                    hoveredTagId = nil
+                }
+            }
+        )
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(tag.color)
+                .frame(width: 6, height: 6)
+            Text(tag.name)
+                .font(.system(size: 11, weight: .medium))
+        }
+        .foregroundStyle(isDropTargeted ? tag.color : .secondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(
+            Capsule()
+                .fill(isDropTargeted ? tag.color.opacity(0.15) : Color.gray.opacity(0.1))
+        )
+        .overlay(
+            Capsule()
+                .strokeBorder(isDropTargeted ? tag.color.opacity(0.5) : Color.clear, lineWidth: 1)
+        )
+        .scaleEffect(isDropTargeted ? 1.2 : 1.0)
+        .opacity(isOthersTargeted ? 0.3 : 1.0)
+        .animation(.easeInOut(duration: 0.2), value: hoveredTagId)
+        .onDrop(
+            of: [.url],
+            isTargeted: isTargetedBinding
+        ) { providers in
+            defer { hoveredTagId = nil }
+            guard let provider = providers.first else { return false }
+            provider.loadDataRepresentation(
+                forTypeIdentifier: UTType.url.identifier
+            ) { data, error in
+                if let error {
+                    os_log(.error, "TagDropPill: failed to load item URL — %{public}@",
+                           error.localizedDescription)
+                    return
+                }
+                guard let data = data,
+                      let urlString = String(data: data, encoding: .utf8),
+                      let url = URL(string: urlString),
+                      url.scheme == "deckitem",
+                      let itemId = Int64(url.lastPathComponent)
+                else { return }
+                DispatchQueue.main.async {
+                    DeckDataStore.shared.updateItemTag(itemId: itemId, tagId: tag.id)
+                }
+            }
+            return true
         }
     }
 }


### PR DESCRIPTION
## ✨ 新功能简介 (New Features)

本次 PR 为 Deck 添加了两个提升剪贴板流转效率的重要扩展功能（这个功能我觉得很好用，请务必加上这个功能，其实本来打算提issue的……）：

### 1. 拖拽分配标签 (Drag-to-Tag)
替代了原有的“右键 -> 添加到分组 -> 选标签”的三步繁琐操作：
- 用户现在可以直接在历史列表中按住剪贴板卡片，将其向下**拖拽至底部的标签栏 (TagDropBar)**。
- 在拖拽时，卡片带有缩放和半透明视觉反馈，其他未被选中的标签会自动淡出（聚光灯效果）。
- 松开鼠标即可快速将该标签分配给对应的剪贴板条目。

### 2. 独立垃圾箱机制与软删除 (Trash Capsule & Soft Delete)
引入了回收站机制，防止意外误删重要剪贴内容，并将其自然融入了标签栏右侧的全新胶囊按钮中：
- **拖拽删除**：胶囊按钮左半边为垃圾桶图标，拖拽卡片到此处会高亮变红，松手即可“软删除”该条目。
- **垃圾箱视图**：胶囊按钮右半边为归档图标，点击可弹出垃圾箱列表面板。
- **恢复与彻底删除**：在垃圾箱中，可以一键恢复数据（并且**完美保留其被删前的原生标签绑定状态**），也可以进行不可逆的彻底删除（带有系统原生警告弹窗防误触）。
- **安全底层架构**：在 `DeckSQLManager` 层面实现了安全的软删除逻辑，为 API 引入了 `permanent: Bool`，**严格兼容并保留了项目原本的硬删除业务语义**，绝不产生破坏性副作用。

---

## 🛠 设计与优化说明 (Design Note)
- ⚠️ **UI 设计待优化**：虽然交互逻辑和底层数据链路已完全跑通，但目前的 UI 布局及样式细节（如标签胶囊比例、垃圾箱列表弹出动画等）可能还比较粗糙。我们期望优先合入功能逻辑，而这部分视觉表现**强烈建议在未来的迭代中进一步打磨和优化**，以更贴合 Deck 整体的美学风格。

代码已通过极高标准的静态审查。期待并感谢您的合并！


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds drag‑to‑tag on the history list and a soft‑delete trash bin to speed up organizing and recovery. Includes a bottom TagDropBar with tag pills and a trash capsule; drag previews are translucent for clearer drop targets.

- **New Features**
  - Drag a clip onto the TagDropBar to assign a tag; hovered tag scales and others fade.
  - Shares internal item URL via `UTType.url` as `deckitem://item/<id>` (own‑process) and decodes on drop to update tags.
  - Trash capsule: left dropzone soft‑deletes; right opens a Trash panel to restore (keeps original tags) or permanently delete with confirmation.
  - Main list hides soft‑deleted items (Trash panel lists them); Tag bar shows only when there are items and user/important tags.

- **Migration**
  - Schema v10 adds `is_deleted` to `ClipboardHistory`; migration runs automatically.
  - `DeckSQLManager.delete(id:permanent:)` supports soft delete; default remains permanent.
  - New APIs: `fetchDeletedItems`, `updateIsDeleted`; list queries filter out deleted by default; search cache invalidation preserved.

<sup>Written for commit aa411d8e9dbe22accf8a312a3fda507799f5d31f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/yuzeguitarist/Deck/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soft-delete with a trash bin to recover or permanently remove items.
  * Trash view with restore and permanent-delete actions.
  * Drag-and-drop tagging bar in the history view for quick tagging.
  * Improved drag preview rendering during drag operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->